### PR TITLE
Silence future-compatibility warnings in 2.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,10 @@ pants list 'src/**/*.py'  # Just targets containing Python code.
 ```
 
 
-## Run linters and formatters
+## Run linters, formatters and fixers
 
 ```
-pants fmt lint ::  # First format, then lint all sources.
+pants fix lint ::  # First format and fix, then lint all sources.
 ```
 
 

--- a/pants.toml
+++ b/pants.toml
@@ -4,7 +4,7 @@ pants_version = "2.16.0"
 backend_packages = [
   "pants.backend.docker",
   "pants.backend.docker.lint.hadolint",
-  "pants.backend.experimental.python.lint.autoflake",
+  "pants.backend.python.lint.autoflake",
   "pants.backend.python",
   "pants.backend.python.lint.black",
   "pants.backend.python.lint.docformatter",

--- a/src/docker/hello_world/BUILD
+++ b/src/docker/hello_world/BUILD
@@ -22,7 +22,7 @@ docker_image(
 
 shell_command(
     name="hello_msg",
-    output_dependencies=["src/shell/hello_world"],
+    execution_dependencies=["src/shell/hello_world"],
     output_files=["msg.txt"],
     command="../../shell/hello_world/main.sh > msg.txt",
     tools=["echo", "sh"],

--- a/src/docker/hello_world/BUILD
+++ b/src/docker/hello_world/BUILD
@@ -23,7 +23,7 @@ docker_image(
 shell_command(
     name="hello_msg",
     output_dependencies=["src/shell/hello_world"],
-    outputs=["msg.txt"],
+    output_files=["msg.txt"],
     command="../../shell/hello_world/main.sh > msg.txt",
     tools=["echo", "sh"],
 )


### PR DESCRIPTION
Running Pants 2.16 in this repository has various warnings, and it causes breakage in 2.17. This fixes those warnings, and now `DYNAMIC_TAG=1 PANTS_VERSION=2.17.0rc2 pants tailor --check update-build-files --check fix lint test package ::` works.

Warnings:

```
08:57:03.06 [WARN] DEPRECATED: The autoflake plugin has moved to `pants.backend.python.lint.autoflake` (and from the `fmt` goal to the `fix` goal).

...

08:57:07.98 [WARN] DEPRECATED: the 'outputs' field is scheduled to be removed in version 2.17.0.dev0.

Using the `outputs` field in the target src/docker/hello_world:hello_msg. To fix, use `output_files` and `output_directories` instead.

...

08:57:12.38 [WARN] DEPRECATED: Using `dependencies` to specify execution-time dependencies for `shell_command`  is scheduled to be removed in version 2.17.0.dev0.

To clear this warning, use the `output_dependencies` and `execution_dependencies`fields. Set `execution_dependencies=()` if you have no execution-time dependencies.

```

This was detected by public repos tests runs like https://github.com/pantsbuild/pants/actions/runs/5592922948/jobs/10226005348