### PR TITLE
Add example using GHA cache backend

### DIFF
--- a/.github/workflows/pants.yaml
+++ b/.github/workflows/pants.yaml
@@ -5,7 +5,7 @@
 
 name: Pants
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   org-check:
@@ -30,6 +30,9 @@ jobs:
     - uses: docker/setup-buildx-action@v3
       with:
         install: true
+    # Exposes Github env vars needed for docker caching - see https://github.com/orgs/community/discussions/42856
+    - name: Expose GitHub Runtime
+      uses: crazy-max/ghaction-github-runtime@v3    
     - uses: pantsbuild/actions/init-pants@v5-scie-pants
       # This action bootstraps pants and manages 2-3 GHA caches.
       # See: github.com/pantsbuild/actions/tree/main/init-pants/
@@ -61,7 +64,7 @@ jobs:
       env:
         DYNAMIC_TAG: workflow
       run: |
-        pants package ::
+        pants --docker-build-verbose package ::
     - name: Upload Pants log
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/pants.yaml
+++ b/.github/workflows/pants.yaml
@@ -17,7 +17,7 @@ jobs:
         run: "true"
   build:
     name: Perform CI Checks
-    needs: org-check
+    # needs: org-check
     runs-on: ubuntu-20.04
     strategy:
       matrix:

--- a/.github/workflows/pants.yaml
+++ b/.github/workflows/pants.yaml
@@ -27,12 +27,26 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+    - uses: crazy-max/ghaction-setup-docker@v3
+      with:
+        daemon-config: |
+            {
+              "features": {
+                "containerd-snapshotter": true
+              }
+            }       
     - uses: docker/setup-buildx-action@v3
       with:
         install: true
+        driver: docker
+    # Required for multi-platform builds
+    - name: Setup QEMU
+      uses: docker/setup-qemu-action@v3
+      with:
+        platforms: linux/amd64,linux/arm64
     # Exposes Github env vars needed for docker caching - see https://github.com/orgs/community/discussions/42856
     - name: Expose GitHub Runtime
-      uses: crazy-max/ghaction-github-runtime@v3    
+      uses: crazy-max/ghaction-github-runtime@v3
     - uses: pantsbuild/actions/init-pants@v5-scie-pants
       # This action bootstraps pants and manages 2-3 GHA caches.
       # See: github.com/pantsbuild/actions/tree/main/init-pants/

--- a/.github/workflows/pants.yaml
+++ b/.github/workflows/pants.yaml
@@ -5,7 +5,7 @@
 
 name: Pants
 
-on: [pull_request]
+on: [push, pull_request]
 
 jobs:
   org-check:
@@ -17,7 +17,7 @@ jobs:
         run: "true"
   build:
     name: Perform CI Checks
-    # needs: org-check
+    needs: org-check
     runs-on: ubuntu-20.04
     strategy:
       matrix:

--- a/.github/workflows/pants.yaml
+++ b/.github/workflows/pants.yaml
@@ -27,6 +27,9 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+    - uses: docker/setup-buildx-action@v3
+      with:
+        install: true
     - uses: pantsbuild/actions/init-pants@v5-scie-pants
       # This action bootstraps pants and manages 2-3 GHA caches.
       # See: github.com/pantsbuild/actions/tree/main/init-pants/

--- a/pants.toml
+++ b/pants.toml
@@ -1,5 +1,5 @@
 [GLOBAL]
-pants_version = "2.17.0"
+pants_version = "2.19.0.dev2"
 
 backend_packages = [
   "pants.backend.docker",
@@ -28,3 +28,9 @@ interpreter_constraints = ["==3.8.*"]
 
 [python-infer]
 use_rust_parser = true
+
+[docker]
+env_vars = [
+  "DOCKER_BUILDKIT",
+  "BUILDX_BUILDER"
+]

--- a/pants.toml
+++ b/pants.toml
@@ -32,5 +32,7 @@ use_rust_parser = true
 [docker]
 env_vars = [
   "DOCKER_BUILDKIT",
-  "BUILDX_BUILDER"
+  "BUILDX_BUILDER",
+  "ACTIONS_CACHE_URL",
+  "ACTIONS_RUNTIME_TOKEN",
 ]

--- a/pants.toml
+++ b/pants.toml
@@ -1,5 +1,5 @@
 [GLOBAL]
-pants_version = "2.19.0.dev2"
+pants_version = "2.19.0.dev4"
 
 backend_packages = [
   "pants.backend.docker",

--- a/pants.toml
+++ b/pants.toml
@@ -1,5 +1,5 @@
 [GLOBAL]
-pants_version = "2.19.0.dev4"
+pants_version = "2.19.0rc3"
 
 backend_packages = [
   "pants.backend.docker",
@@ -31,8 +31,8 @@ use_rust_parser = true
 
 [docker]
 env_vars = [
-  "DOCKER_BUILDKIT",
-  "BUILDX_BUILDER",
   "ACTIONS_CACHE_URL",
   "ACTIONS_RUNTIME_TOKEN",
+  "DYNAMIC_TAG",
 ]
+use_buildx=true

--- a/src/docker/caching/BUILD
+++ b/src/docker/caching/BUILD
@@ -1,0 +1,14 @@
+# Copyright 2022 Pants project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+docker_image(
+    name="with-local-cache-backend",
+    cache_to={
+        "type": "local",
+        "dest": "/tmp/docker-cache/pants-example"
+    },
+    cache_from={
+        "type": "local",
+        "src": "/tmp/docker-cache/pants-example"
+    }
+)

--- a/src/docker/caching/BUILD
+++ b/src/docker/caching/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 docker_image(
-    name="with-local-cache-backend",
-    cache_to={"type": "local", "dest": "/tmp/docker-cache/pants-example"},
-    cache_from={"type": "local", "src": "/tmp/docker-cache/pants-example"},
+    name="with-gha-cache-backend",
+    cache_to={"type": "gha", "mode": "max"},
+    cache_from={"type": "gha"},
 )

--- a/src/docker/caching/BUILD
+++ b/src/docker/caching/BUILD
@@ -3,12 +3,6 @@
 
 docker_image(
     name="with-local-cache-backend",
-    cache_to={
-        "type": "local",
-        "dest": "/tmp/docker-cache/pants-example"
-    },
-    cache_from={
-        "type": "local",
-        "src": "/tmp/docker-cache/pants-example"
-    }
+    cache_to={"type": "local", "dest": "/tmp/docker-cache/pants-example"},
+    cache_from={"type": "local", "src": "/tmp/docker-cache/pants-example"},
 )

--- a/src/docker/caching/Dockerfile
+++ b/src/docker/caching/Dockerfile
@@ -1,0 +1,3 @@
+FROM alpine@sha256:21a3deaa0d32a8057914f36584b5288d2e5ecc984380bc0118285c70fa8c9300
+
+RUN echo "hello" > msg.txt

--- a/src/docker/caching/Dockerfile
+++ b/src/docker/caching/Dockerfile
@@ -1,3 +1,4 @@
 FROM alpine@sha256:21a3deaa0d32a8057914f36584b5288d2e5ecc984380bc0118285c70fa8c9300
 
-RUN echo "hello" > msg.txt
+RUN echo "hello" > msg.txt && \
+  sleep 60

--- a/src/docker/multiplatform/BUILD
+++ b/src/docker/multiplatform/BUILD
@@ -1,0 +1,15 @@
+# Note that multistage buildx builds requires using the containerd image store, due to
+# limitations with the docker-container driver (https://github.com/moby/buildkit/issues/2343)
+
+docker_image(
+    name="multiplatform-base",
+    source="Dockerfile.base",
+    skip_push=True,
+    build_platform=["linux/amd64", "linux/arm64"],
+)
+
+docker_image(
+    name="multiplatform-final",
+    source="Dockerfile.final",
+    build_platform=["linux/amd64", "linux/arm64"],
+)

--- a/src/docker/multiplatform/Dockerfile.base
+++ b/src/docker/multiplatform/Dockerfile.base
@@ -1,0 +1,3 @@
+FROM python:3.8
+
+RUN echo "base image" >> base.txt

--- a/src/docker/multiplatform/Dockerfile.final
+++ b/src/docker/multiplatform/Dockerfile.final
@@ -1,0 +1,6 @@
+ARG PARENT=:multiplatform-base
+# hadolint ignore=DL3006
+FROM ${PARENT}
+
+RUN cat base.txt && \
+  echo "final image" >> final.txt


### PR DESCRIPTION
Raising for info at this stage pending 2.19 release. 

Note that no changes are required to run this locally - i.e. it will not fail due to missing GH tokens but fall back to local cache if present. 

I think I will also attempt to add an example using the Inline cache backend, publishing to Github packages - this seems a better option when there are many images as the GHA cache limit would be reached. 