### PR TITLE
Replaced 3rd party script with first-party script exposing GH vars

### DIFF
--- a/.github/workflows/pants.yaml
+++ b/.github/workflows/pants.yaml
@@ -15,6 +15,7 @@ jobs:
     steps:
       - name: Noop
         run: "true"
+
   build:
     name: Perform CI Checks
     needs: org-check
@@ -23,65 +24,79 @@ jobs:
       matrix:
         python-version: [3.8]
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
-    - uses: crazy-max/ghaction-setup-docker@v3
-      with:
-        daemon-config: |
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - uses: crazy-max/ghaction-setup-docker@v3
+        with:
+          daemon-config: |
             {
               "features": {
                 "containerd-snapshotter": true
               }
-            }       
-    - uses: docker/setup-buildx-action@v3
-      with:
-        install: true
-        driver: docker
-    # Required for multi-platform builds
-    - name: Setup QEMU
-      uses: docker/setup-qemu-action@v3
-      with:
-        platforms: linux/amd64,linux/arm64
-    # Exposes Github env vars needed for docker caching - see https://github.com/orgs/community/discussions/42856
-    - name: Expose GitHub Runtime
-      uses: crazy-max/ghaction-github-runtime@v3
-    - uses: pantsbuild/actions/init-pants@v5-scie-pants
-      # This action bootstraps pants and manages 2-3 GHA caches.
-      # See: github.com/pantsbuild/actions/tree/main/init-pants/
-      with:
-        # v0 makes it easy to bust the cache if needed
-        # just increase the integer to start with a fresh cache
-        gha-cache-key: v0
-        # This repo has no 3rd-party requirements and no lockfiles, so we don't invalidate
-        # the named caches on anything extra. See other example repos for better examples of
-        # how to set up this cache.
-        named-caches-hash: ""
-        # If you're not using a fine-grained remote caching service (see https://www.pantsbuild.org/docs/remote-caching),
-        # then you may also want to preserve the local Pants cache (lmdb_store). However this must invalidate for
-        # changes to any file that can affect the build, so may not be practical in larger repos.
-        # A remote cache service integrates with Pants's fine-grained invalidation and avoids these problems.
-        cache-lmdb-store: 'true'  # defaults to 'false'
-        # Note that named_caches and lmdb_store falls back to partial restore keys which
-        # may give a useful partial result that will save time over completely clean state,
-        # but will cause the cache entry to grow without bound over time.
-        # See https://www.pantsbuild.org/2.21/docs/using-pants/using-pants-in-ci for tips on how to periodically clean it up.
-        # Alternatively you change gha-cache-key to ignore old caches.
-    - name: Bootstrap Pants
-      run: pants --version
-    - name: Check Pants config files
-      run: pants tailor --check update-build-files --check '::'
-    - name: Lint, compile, and test
-      run: pants lint check test '::'
-    - name: Package / Run
-      env:
-        DYNAMIC_TAG: workflow
-      run: |
-        pants --docker-build-verbose package ::
-    - name: Upload Pants log
-      uses: actions/upload-artifact@v3
-      with:
-        name: pants-log
-        path: .pants.d/pants.log
-      if: always()  # We want the log even on failures.
+            }
+
+      - uses: docker/setup-buildx-action@v3
+        with:
+          install: true
+          driver: docker
+
+      # Required for multi-platform builds
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
+
+      - name: Set up environment variables for Pants (Docker) to use GHA Cache
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.exportVariable("ACTIONS_CACHE_URL", process.env.ACTIONS_CACHE_URL || "");
+            core.exportVariable("ACTIONS_RUNTIME_TOKEN", process.env.ACTIONS_RUNTIME_TOKEN || "");
+
+      - uses: pantsbuild/actions/init-pants@v9
+        # This action bootstraps pants and manages 2-3 GHA caches.
+        # See: github.com/pantsbuild/actions/tree/main/init-pants/
+        with:
+          # v0 makes it easy to bust the cache if needed
+          # just increase the integer to start with a fresh cache
+          gha-cache-key: v0
+          # This repo has no 3rd-party requirements and no lockfiles, so we don't invalidate
+          # the named caches on anything extra. See other example repos for better examples of
+          # how to set up this cache.
+          named-caches-hash: ""
+          # If you're not using a fine-grained remote caching service (see https://www.pantsbuild.org/docs/remote-caching),
+          # then you may also want to preserve the local Pants cache (lmdb_store). However this must invalidate for
+          # changes to any file that can affect the build, so may not be practical in larger repos.
+          # A remote cache service integrates with Pants's fine-grained invalidation and avoids these problems.
+          cache-lmdb-store: "true" # defaults to 'false'
+          # Note that named_caches and lmdb_store falls back to partial restore keys which
+          # may give a useful partial result that will save time over completely clean state,
+          # but will cause the cache entry to grow without bound over time.
+          # See https://www.pantsbuild.org/2.21/docs/using-pants/using-pants-in-ci for tips on how to periodically clean it up.
+          # Alternatively you change gha-cache-key to ignore old caches.
+
+      - name: Bootstrap Pants
+        run: pants --version
+
+      - name: Check Pants config files
+        run: pants tailor --check update-build-files --check '::'
+
+      - name: Lint, compile, and test
+        run: pants lint check test '::'
+
+      - name: Package / Run
+        env:
+          DYNAMIC_TAG: workflow
+        run: |
+          pants --docker-build-verbose package ::
+
+      - name: Upload Pants log
+        uses: actions/upload-artifact@v3
+        with:
+          name: pants-log
+          path: .pants.d/pants.log
+        if: always() # We want the log even on failures.


### PR DESCRIPTION
This PR explicitly exposes the two GH `ACTION` environment variables we need. This means we pull one less 3rd party dep (in favour of a GH dep), but more importantly, we directly expose the two env vars we need

Assuming Pants users will cargo cult this file, I think being a bit more explicit is nice.

Also updated actions to v9, and formatted with Prettier. Ran `actionlint` over the code to no complaints.