### PR TITLE
Upgrade to Pants 2.25.1

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -1,5 +1,5 @@
 [GLOBAL]
-pants_version = "2.25.1rc0"
+pants_version = "2.25.1"
 
 backend_packages = [
   "pants.backend.docker",


### PR DESCRIPTION
Issue https://github.com/pantsbuild/pants/issues/22108 blocked using 2.25.0, but has now been released in the stable 2.25.1.